### PR TITLE
Add an option to adjust the margin around the category names

### DIFF
--- a/data/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
+++ b/data/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
@@ -23,5 +23,10 @@
             <summary>Show the category view by default</summary>
             <description>Save the current view of the launcher.</description>
         </key>
+        <key name="category-margin" type="i">
+            <default>0</default>
+            <range min="0" max="15"/>
+            <summary>Margin size around each category name</summary>
+        </key>
 	</schema>
 </schemalist>

--- a/data/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
+++ b/data/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
@@ -23,10 +23,10 @@
             <summary>Show the category view by default</summary>
             <description>Save the current view of the launcher.</description>
         </key>
-        <key name="category-margin" type="i">
+        <key name="category-spacing" type="i">
             <default>0</default>
-            <range min="0" max="15"/>
-            <summary>Margin size around each category name</summary>
+            <range min="-15" max="15"/>
+            <summary>Spacing size around each category name</summary>
         </key>
 	</schema>
 </schemalist>

--- a/src/AppMenu.vala
+++ b/src/AppMenu.vala
@@ -57,7 +57,7 @@ namespace AppMenuApplet {
         private Gtk.Switch? switch_rollover;
 
         [GtkChild]
-        private Gtk.SpinButton spin_category_margin;
+        private Gtk.SpinButton spin_category_spacing;
 
         private GLib.Settings? settings;
         private static GLib.Settings appmenu_settings { get; private set; default = null; }
@@ -76,7 +76,7 @@ namespace AppMenuApplet {
             appmenu_settings.bind("rows", spin_rows, "value", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("enable-powerstrip", switch_powerstrip, "active", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("rollover-menu", switch_rollover, "active", SettingsBindFlags.DEFAULT);
-            appmenu_settings.bind("category-margin", spin_category_margin, "value", SettingsBindFlags.DEFAULT);
+            appmenu_settings.bind("category-spacing", spin_category_spacing, "value", SettingsBindFlags.DEFAULT);
 
             this.button_icon_pick.clicked.connect(on_pick_click);
         }

--- a/src/AppMenu.vala
+++ b/src/AppMenu.vala
@@ -56,6 +56,9 @@ namespace AppMenuApplet {
         [GtkChild]
         private Gtk.Switch? switch_rollover;
 
+        [GtkChild]
+        private Gtk.SpinButton spin_category_margin;
+
         private GLib.Settings? settings;
         private static GLib.Settings appmenu_settings { get; private set; default = null; }
 
@@ -73,6 +76,7 @@ namespace AppMenuApplet {
             appmenu_settings.bind("rows", spin_rows, "value", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("enable-powerstrip", switch_powerstrip, "active", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("rollover-menu", switch_rollover, "active", SettingsBindFlags.DEFAULT);
+            appmenu_settings.bind("category-margin", spin_category_margin, "value", SettingsBindFlags.DEFAULT);
 
             this.button_icon_pick.clicked.connect(on_pick_click);
         }

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -43,6 +43,8 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
         set_visible_window (false);
         hexpand = true;
 
+        define_css_styles();
+
         category_switcher = new NavListBox ();
         category_switcher.selection_mode = Gtk.SelectionMode.BROWSE;
         category_switcher.set_sort_func ((Gtk.ListBoxSortFunc) category_sort_func);
@@ -161,9 +163,34 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
             rollover_menus = settings.get_boolean("rollover-menu");
         });
 
-        settings.changed["category-margin"].connect(() => {
+        settings.changed["category-spacing"].connect(() => {
             setup_sidebar ();
         });
+    }
+
+    private void define_css_styles() {
+        var css_builder = new StringBuilder ();
+        for (int spacing = -15; spacing <= 15; ++spacing) {
+            int bottom = spacing / 2;
+            int top = spacing - bottom;
+
+            css_builder.append_printf ("""
+                .budgie_application_menu_category_row_%d {
+                    margin: %dpx 3px %dpx 3px;
+                }
+                """, spacing, top, bottom);
+        }
+
+        Gdk.Screen screen = this.get_screen ();
+        Gtk.CssProvider css_provider = new Gtk.CssProvider ();
+        try {
+            css_provider.load_from_data (css_builder.str);
+            Gtk.StyleContext.add_provider_for_screen (
+                screen, css_provider, Gtk.STYLE_PROVIDER_PRIORITY_USER);
+        }
+        catch (Error e) {
+            message("Could not load css %s", e.message);
+        }
     }
 
     private static int category_sort_func (CategoryRow row1, CategoryRow row2) {
@@ -243,7 +270,7 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
         listbox.show_all ();
 
         // Fill the sidebar
-        int category_margin = settings.get_int ("category-margin");
+        int category_spacing = settings.get_int ("category-spacing");
 
         unowned Gtk.ListBoxRow? new_selected = null;
         foreach (string cat_name in view.app_system.apps.keys) {
@@ -251,7 +278,7 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
                 continue;
             }
 
-            var row = new CategoryRow (cat_name, category_margin);
+            var row = new CategoryRow (cat_name, category_spacing);
             row.eventbox.enter_notify_event.connect(this.on_mouse_enter);
             category_switcher.add (row);
             if (old_selected != null && old_selected.cat_name == cat_name) {
@@ -317,7 +344,7 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
 
     private class CategoryRow : Gtk.ListBoxRow {
         public string cat_name { get; construct; }
-        public int margin { get; construct; }
+        public int cat_margin { get; construct; }
         public Gtk.EventBox eventbox;
         public string translated_name {
             get {
@@ -325,21 +352,21 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
             }
         }
 
-        public CategoryRow (string cat_name, int margin) {
-            Object (cat_name: cat_name, margin: margin);
+        public CategoryRow (string cat_name, int cat_margin) {
+            Object (cat_name: cat_name, cat_margin: cat_margin);
         }
 
         construct {
             var label = new Gtk.Label (translated_name);
             label.halign = Gtk.Align.START;
-            label.margin_start  = this.margin + 3;
-            label.margin_end    = this.margin + 3;
-            label.margin_top    = this.margin;
-            label.margin_bottom = this.margin;
+            label.margin = 0;
+            label.get_style_context().add_class("budgie_application_menu_category_row_%d".printf(this.cat_margin));
+
             eventbox = new Gtk.EventBox();
             eventbox.add(label);
             eventbox.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
-            add (eventbox);
+
+            this.add (eventbox);
         }
     }
 

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -14,8 +14,8 @@
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
   </object>
-  <object class="GtkAdjustment" id="adjustment_category_margin">
-    <property name="lower">0</property>
+  <object class="GtkAdjustment" id="adjustment_category_spacing">
+    <property name="lower">-15</property>
     <property name="upper">15</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
@@ -231,7 +231,8 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">start</property>
-        <property name="label" translatable="yes" comments="Margin size around each category name">Category Margin</property>
+        <property name="label" translatable="yes" comments="Spacing around each category name">Adjust Category
+Spacing</property>
       </object>
       <packing>
         <property name="left_attach">0</property>
@@ -239,11 +240,12 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSpinButton" id="spin_category_margin">
+      <object class="GtkSpinButton" id="spin_category_spacing">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
+        <property name="valign">center</property>
         <property name="input_purpose">digits</property>
-        <property name="adjustment">adjustment_category_margin</property>
+        <property name="adjustment">adjustment_category_spacing</property>
         <property name="snap_to_ticks">True</property>
         <property name="numeric">True</property>
       </object>

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -2,15 +2,21 @@
 <!-- Generated with glade 3.36.0 -->
 <interface>
   <requires lib="gtk+" version="3.12"/>
-  <object class="GtkAdjustment" id="adjustment1">
+  <object class="GtkAdjustment" id="adjustment_rows">
     <property name="lower">2</property>
     <property name="upper">10</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
   </object>
-  <object class="GtkAdjustment" id="adjustment2">
+  <object class="GtkAdjustment" id="adjustment_colums">
     <property name="lower">2</property>
     <property name="upper">10</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_category_margin">
+    <property name="lower">0</property>
+    <property name="upper">15</property>
     <property name="step_increment">1</property>
     <property name="page_increment">1</property>
   </object>
@@ -82,7 +88,7 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="input_purpose">digits</property>
-        <property name="adjustment">adjustment1</property>
+        <property name="adjustment">adjustment_rows</property>
         <property name="snap_to_ticks">True</property>
         <property name="numeric">True</property>
       </object>
@@ -96,7 +102,7 @@
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="input_purpose">digits</property>
-        <property name="adjustment">adjustment2</property>
+        <property name="adjustment">adjustment_colums</property>
         <property name="snap_to_ticks">True</property>
         <property name="numeric">True</property>
       </object>
@@ -218,6 +224,32 @@
       <packing>
         <property name="left_attach">1</property>
         <property name="top_attach">6</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="halign">start</property>
+        <property name="label" translatable="yes" comments="Margin size around each category name">Category Margin</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">7</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSpinButton" id="spin_category_margin">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="input_purpose">digits</property>
+        <property name="adjustment">adjustment_category_margin</property>
+        <property name="snap_to_ticks">True</property>
+        <property name="numeric">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">7</property>
       </packing>
     </child>
   </template>


### PR DESCRIPTION
Hi,
This PR adds an option to adjust the margin around the category names.

IMHO, the categories on the left column are displayed too densely. 
![Screenshot 2021-06-29 03:54:57](https://user-images.githubusercontent.com/30318985/123690611-83e9e980-d88f-11eb-8e2b-bb8cb35137d4.png)

So I have added an option to change the margin according to your preferences like this:
![Screenshot 2021-06-29 03:55:14](https://user-images.githubusercontent.com/30318985/123690818-cc090c00-d88f-11eb-8ee5-acea0e0834f7.png)
