### PR TITLE
Added setting for whether to show terminal apps or not

### DIFF
--- a/data/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
+++ b/data/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
@@ -28,5 +28,10 @@
             <range min="-15" max="15"/>
             <summary>Spacing size around each category name</summary>
         </key>
+        <key name="show-terminal-apps" type="b">
+            <default>false</default>
+            <summary>Show terminal applications</summary>
+            <description>Show applications whose .desktop file contains 'Terminal=true'.</description>
+        </key>
 	</schema>
 </schemalist>

--- a/src/AppMenu.vala
+++ b/src/AppMenu.vala
@@ -51,6 +51,9 @@ namespace AppMenuApplet {
         private unowned Gtk.SpinButton spin_columns;
 
         [GtkChild]
+        private unowned Gtk.Switch? show_terminal_apps;
+
+        [GtkChild]
         private unowned Gtk.Switch? switch_powerstrip;
 
         [GtkChild]
@@ -74,6 +77,7 @@ namespace AppMenuApplet {
             settings.bind("menu-icon", entry_icon_pick, "text", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("columns", spin_columns, "value", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("rows", spin_rows, "value", SettingsBindFlags.DEFAULT);
+            appmenu_settings.bind("show-terminal-apps", show_terminal_apps, "active", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("enable-powerstrip", switch_powerstrip, "active", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("rollover-menu", switch_rollover, "active", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("category-spacing", spin_category_spacing, "value", SettingsBindFlags.DEFAULT);

--- a/src/Backend/App.vala
+++ b/src/Backend/App.vala
@@ -40,6 +40,7 @@ public class Slingshot.Backend.App : Object {
     public string generic_name { get; private set; default = ""; }
     public bool prefers_default_gpu { get; private set; default = false; }
     public AppType app_type { get; private set; default = AppType.APP; }
+    public bool terminal { get; private set; default = false; }
 
 #if HAS_PLANK
     private string? unity_sender_name = null;
@@ -69,6 +70,7 @@ public class Slingshot.Backend.App : Object {
         categories = info.get_categories ();
         generic_name = info.get_generic_name ();
         prefers_default_gpu = !info.get_boolean ("PrefersNonDefaultGPU");
+        terminal = info.get_boolean ("Terminal");
 
         var desktop_icon = info.get_icon ();
         if (desktop_icon != null) {

--- a/src/Backend/AppSystem.vala
+++ b/src/Backend/AppSystem.vala
@@ -166,10 +166,6 @@ public class Slingshot.Backend.AppSystem : Object {
                 continue;
             }
 
-            if (desktop_app.get_boolean ("Terminal")) {
-                continue;
-            }
-
             string control_center = "gnome-control-center";
 
             if (Environment.find_program_in_path("budgie-control-center") != null) {

--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -185,6 +185,11 @@ public class Slingshot.SlingshotView : Gtk.Grid {
             grid_view.populate (app_system);
         });
 
+        settings.changed["show-terminal-apps"].connect_after(() => {
+            grid_view.populate (app_system);
+            category_view.setup_sidebar ();
+        });
+
         powerstrip.invoke_action.connect(() => {
             close_indicator ();
         });

--- a/src/Views/CategoryView.vala
+++ b/src/Views/CategoryView.vala
@@ -295,7 +295,7 @@ public class Slingshot.Widgets.CategoryView : Gtk.EventBox {
         unowned CategoryRow category_row = (CategoryRow) category_switcher.get_selected_row ();
         if (category_row != null) {
             foreach (Backend.App app in view.app_system.apps[category_row.cat_name]) {
-                if (row.app_id == app.desktop_id) {
+                if (row.app_id == app.desktop_id && !(app.terminal && !settings.get_boolean("show-terminal-apps"))) {
                     return true;
                 }
             }

--- a/src/Views/GridView.vala
+++ b/src/Views/GridView.vala
@@ -88,6 +88,9 @@ public class Slingshot.Widgets.Grid : Gtk.Grid {
         paginator.scroll_to (current_grid);
 
         foreach (Backend.App app in app_system.get_apps_by_name ()) {
+            if (!settings.get_boolean("show-terminal-apps") && app.terminal )
+                continue;
+
             var app_button = new Widgets.AppButton (app);
             app_button.app_launched.connect (() => app_launched ());
 

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -181,7 +181,19 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSwitch" id="switch_powerstrip">
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Show Terminal Applications</property>
+        <property name="xalign">0</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="show_terminal_apps">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="halign">end</property>
@@ -189,6 +201,17 @@
       <packing>
         <property name="left_attach">1</property>
         <property name="top_attach">5</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_powerstrip">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">6</property>
       </packing>
     </child>
     <child>
@@ -200,7 +223,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">5</property>
+        <property name="top_attach">6</property>
       </packing>
     </child>
     <child>
@@ -212,7 +235,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">6</property>
+        <property name="top_attach">7</property>
       </packing>
     </child>
     <child>
@@ -223,7 +246,7 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">6</property>
+        <property name="top_attach">7</property>
       </packing>
     </child>
     <child>
@@ -236,7 +259,7 @@ Spacing</property>
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">7</property>
+        <property name="top_attach">8</property>
       </packing>
     </child>
     <child>
@@ -251,7 +274,7 @@ Spacing</property>
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">7</property>
+        <property name="top_attach">8</property>
       </packing>
     </child>
   </template>


### PR DESCRIPTION
As discussed previously in https://github.com/UbuntuBudgie/budgie-extras/issues/485 this is fulfilling a request for a setting to show or hide terminal apps (which I think it an excellent idea :)). By default it will hide terminal apps. This way terminal apps can be shown or not. Also made it so that switching this will refresh both the grid and category view. 

Current situation is that they are always hidden and only show up during search function. This way that is no longer needed.