### PR TITLE
Small fix on exclusion of certain apps

### DIFF
--- a/src/Backend/AppSystem.vala
+++ b/src/Backend/AppSystem.vala
@@ -146,14 +146,13 @@ public class Slingshot.Backend.AppSystem : Object {
             new Category (_("System Tools")) {
                 included_categories = { "System", "Administration", "Settings" },
                 excluded_categories = { "Game" },
-                excluded_applications = { "htop.desktop", "onboard.desktop", "onboard-settings.desktop" }
+                excluded_applications = { "onboard-settings.desktop" }
             }
         );
 
         var other_category =
             new Category (_("Other"), true) {
                 excluded_categories = { "Core", "Screensaver", "Settings" },
-                excluded_applications = { "htop.desktop", "onboard.desktop", "org.gnome.FileRoller.desktop", "org.gnome.font-viewer.desktop" }
             };
 
         foreach (var app in GLib.AppInfo.get_all ()) {


### PR DESCRIPTION
So from what I could gather within the setup of categories certain apps are being excluded as they could appear in certain categories, and this way being forced to be other categories?

I am not sure if this is intended to be like this as well you could push a lot of apps in certain categories then but anyway. I noticed a couple of things..

1) Htop as terminal app was already excluded, but after making my terminal-app switch I noticed it was completely ignored, it should be in system as it is only caught there but it is excluded, so I took that one out.
2) All 4 app exclusions in the 'Other' category are pointless as they are caught in other categories, I confirmed this directly with fileroller and font-viewer, as well with htop with my other pull request, as for onboard.desktop, I checked the source and it should be caught under 'Universal Access' making it also obsolete. Therefore I took them all out.
3) Onboard.desktop can never fall under the System category as it doesn't have any of those categories and thus was also taken out there..

For which the above 3 points I made this pull request.

Some other things to look into, but was not able to directly confirm, Education excludes Science but Science _includes_ Education, that can't be right, right? Does that mean all education apps go into 2 categories? Or are they put into 1 and then ignored for the other one? If so then that inclusion could be edited out as well as it is pretty confusing..
As for Science category to exclude libreoffice-math.desktop I can see the case for that to force it into Office category..

As I do not have any science or education application I can't check my suspicions with those 2 categories and thus only changed of that which I am certain of and tested, which was the 3 points stated above.

Also it does make me wonder in how far the menu should micro manage individual applications into which menu category they go though.. But that is just my opinion.. 

Can applications be shown under multiple categories? Like onboard-settings.desktop, It already falls under Universal Access, will it still be caught and also shown under System? If not that then even that exclusion can be taken out..

Anyway food for thought, pull request is of that which IMHO should be changed, at the very least to make sure htop is not fully excluded from the menu as a whole.