### PR TITLE
Add an optional favourite sidebar

### DIFF
--- a/data/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
+++ b/data/org.ubuntubudgie.plugins.budgie-appmenu.gschema.xml
@@ -33,5 +33,13 @@
             <summary>Show terminal applications</summary>
             <description>Show applications whose .desktop file contains 'Terminal=true'.</description>
         </key>
+        <key type="b" name="enable-favorites">
+        <default>false</default>
+        <summary>Enable favorites sidebar</summary>
+        </key>
+        <key type="as" name="favorites">
+        <default>[]</default>
+        <summary>Favorite applications</summary>
+        </key>
 	</schema>
 </schemalist>

--- a/src/AppMenu.vala
+++ b/src/AppMenu.vala
@@ -62,6 +62,9 @@ namespace AppMenuApplet {
         [GtkChild]
         private unowned Gtk.SpinButton spin_category_spacing;
 
+        [GtkChild]
+        private unowned Gtk.Switch? switch_favorites;
+
         private GLib.Settings? settings;
         private static GLib.Settings appmenu_settings { get; private set; default = null; }
 
@@ -81,6 +84,7 @@ namespace AppMenuApplet {
             appmenu_settings.bind("enable-powerstrip", switch_powerstrip, "active", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("rollover-menu", switch_rollover, "active", SettingsBindFlags.DEFAULT);
             appmenu_settings.bind("category-spacing", spin_category_spacing, "value", SettingsBindFlags.DEFAULT);
+            appmenu_settings.bind("enable-favorites", switch_favorites, "active", SettingsBindFlags.DEFAULT);
 
             this.button_icon_pick.clicked.connect(on_pick_click);
         }

--- a/src/Backend/FavoritesManager.vala
+++ b/src/Backend/FavoritesManager.vala
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Ubuntu Budgie Developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+namespace Slingshot.Backend {
+    public class FavoritesManager : Object {
+        private static FavoritesManager? instance = null;
+        private GLib.Settings settings;
+        private Gee.ArrayList<string> favorites_list;
+
+        public signal void favorites_changed ();
+
+        public static FavoritesManager get_default () {
+            if (instance == null) {
+                instance = new FavoritesManager ();
+            }
+            return instance;
+        }
+
+        construct {
+            settings = new GLib.Settings ("org.ubuntubudgie.plugins.budgie-appmenu");
+            favorites_list = new Gee.ArrayList<string> ();
+            load_favorites ();
+
+            settings.changed["favorites"].connect (() => {
+                load_favorites ();
+                favorites_changed ();
+            });
+        }
+
+        private void load_favorites () {
+            favorites_list.clear ();
+            string[] favs = settings.get_strv ("favorites");
+            foreach (unowned string fav in favs) {
+                favorites_list.add (fav);
+            }
+        }
+
+        private void save_favorites () {
+            // Create a proper string array to avoid segfault
+            string[] favs = new string[favorites_list.size];
+            int i = 0;
+            foreach (string desktop_id in favorites_list) {
+                favs[i++] = desktop_id;
+            }
+            settings.set_strv ("favorites", favs);
+        }
+
+        public void add_favorite (string desktop_id) {
+            if (!favorites_list.contains (desktop_id)) {
+                favorites_list.add (desktop_id);
+                save_favorites ();
+                favorites_changed ();
+            }
+        }
+
+        public void remove_favorite (string desktop_id) {
+            if (favorites_list.remove (desktop_id)) {
+                save_favorites ();
+                favorites_changed ();
+            }
+        }
+
+        public bool is_favorite (string desktop_id) {
+            return favorites_list.contains (desktop_id);
+        }
+
+        public void move_favorite (int old_index, int new_index) {
+            if (old_index < 0 || old_index >= favorites_list.size ||
+                new_index < 0 || new_index >= favorites_list.size) {
+                return;
+            }
+
+            string item = favorites_list[old_index];
+            favorites_list.remove_at (old_index);
+            favorites_list.insert (new_index, item);
+            save_favorites ();
+            favorites_changed ();
+        }
+
+        public Gee.List<string> get_favorites () {
+            return favorites_list.read_only_view;
+        }
+
+        public void validate_favorites () {
+            var to_remove = new Gee.ArrayList<string> ();
+            var dfs = Synapse.DesktopFileService.get_default ();
+
+            foreach (string desktop_id in favorites_list) {
+                var info = dfs.get_desktop_file_for_id (desktop_id);
+                if (info == null || info.is_hidden || !info.is_valid) {
+                    to_remove.add (desktop_id);
+                }
+            }
+
+            bool changed = false;
+            foreach (string desktop_id in to_remove) {
+                favorites_list.remove (desktop_id);
+                changed = true;
+            }
+
+            if (changed) {
+                save_favorites ();
+                favorites_changed ();
+            }
+        }
+    }
+}

--- a/src/SlingshotView.vala
+++ b/src/SlingshotView.vala
@@ -46,6 +46,9 @@ public class Slingshot.SlingshotView : Gtk.Grid {
     private Gtk.Grid top;
     private Widgets.SearchView search_view;
     private Widgets.CategoryView category_view;
+    private Widgets.FavoritesSidebar? favorites_sidebar = null;
+    private Gtk.Separator? favorites_separator = null;
+    private Gtk.Grid content_grid;
 
     private static GLib.Settings settings { get; private set; default = null; }
 
@@ -108,11 +111,28 @@ public class Slingshot.SlingshotView : Gtk.Grid {
         stack.add_named (category_view, "category");
         stack.add_named (search_view, "search");
 
+        // Create favorites sidebar
+        favorites_sidebar = new Widgets.FavoritesSidebar ();
+        favorites_sidebar.set_app_system (app_system);
+        favorites_sidebar.app_launched.connect (() => {
+            close_indicator ();
+        });
+        favorites_sidebar.no_show_all = true;
+
+        favorites_separator = new Gtk.Separator (Gtk.Orientation.VERTICAL);
+        favorites_separator.no_show_all = true;
+
+        // Create main content grid with favorites
+        content_grid = new Gtk.Grid ();
+        content_grid.attach (favorites_sidebar, 0, 0, 1, 1);
+        content_grid.attach (favorites_separator, 1, 0, 1, 1);
+        content_grid.attach (stack, 2, 0, 1, 1);
+
         container = new Gtk.Grid ();
         container.row_spacing = 12;
         container.margin_bottom = 12;
         container.attach (top, 0, 1);
-        container.attach (stack, 0, 0);
+        container.attach (content_grid, 0, 0);
 
         // This function must be after creating the page switcher
         grid_view.populate (app_system);
@@ -194,6 +214,13 @@ public class Slingshot.SlingshotView : Gtk.Grid {
             close_indicator ();
         });
         powerstrip.set_visible(settings.get_boolean("enable-powerstrip"));
+
+        update_favorites_visibility ();
+        settings.changed["enable-favorites"].connect (() => {
+            update_favorites_visibility ();
+        });
+
+        content_grid.show_all();
     }
 
     public void panel_position_changed(Budgie.PanelPosition position) {
@@ -205,7 +232,7 @@ public class Slingshot.SlingshotView : Gtk.Grid {
             container.remove_row(0);
 
             container.attach (top, 0, 1);
-            container.attach (stack, 0, 0);
+            container.attach (content_grid, 0, 0);
         }
         else {
             container.margin_bottom = 0;
@@ -215,9 +242,9 @@ public class Slingshot.SlingshotView : Gtk.Grid {
             container.remove_row(0);
 
             container.attach (top, 0, 0);
-            container.attach (stack, 0, 1);
+            container.attach (content_grid, 0, 1);
         }
-        container.show_all();
+        content_grid.show_all();
     }
 
 #if HAS_PLANK
@@ -250,6 +277,18 @@ public class Slingshot.SlingshotView : Gtk.Grid {
         }
     }
 #endif
+
+    private void update_favorites_visibility () {
+        bool show_favorites = settings.get_boolean ("enable-favorites");
+
+        if (favorites_sidebar != null) {
+            favorites_sidebar.visible = show_favorites;
+        }
+
+        if (favorites_separator != null) {
+            favorites_separator.visible = show_favorites;
+        }
+    }
 
     private void search_entry_activated () {
         if (modality == Modality.SEARCH_VIEW) {
@@ -394,6 +433,10 @@ public class Slingshot.SlingshotView : Gtk.Grid {
         view_selector_revealer.transition_type = Gtk.RevealerTransitionType.SLIDE_RIGHT;
         powerstrip.set_visible(settings.get_boolean("enable-powerstrip"));
         stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
+
+        if (favorites_sidebar != null && settings.get_boolean ("enable-favorites")) {
+            favorites_sidebar.validate_and_populate ();
+        }
     }
 
     private void set_modality (Modality new_modality) {

--- a/src/Widgets/AppButton.vala
+++ b/src/Widgets/AppButton.vala
@@ -155,21 +155,6 @@ public class Slingshot.Widgets.AppButton : Gtk.Button {
             return Gdk.EVENT_PROPAGATE;
         });
 
-        this.drag_begin.connect ((ctx) => {
-            this.dragging = true;
-            Gtk.drag_set_icon_gicon (ctx, app.icon, 16, 16);
-            //app_launched ();
-        });
-
-        this.drag_end.connect ( () => {
-            this.dragging = false;
-            app_launched ();
-        });
-
-        this.drag_data_get.connect ( (ctx, sel, info, time) => {
-            sel.set_uris ({File.new_for_path (app.desktop_path).get_uri ()});
-        });
-
 #if HAS_PLANK
         app.notify["current-count"].connect (update_badge_count);
         app.notify["count-visible"].connect (update_badge_visibility);

--- a/src/Widgets/AppContextMenu.vala
+++ b/src/Widgets/AppContextMenu.vala
@@ -30,6 +30,8 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
     //private Gtk.MenuItem uninstall_menuitem;
     //private Gtk.MenuItem appcenter_menuitem;
 
+    private Slingshot.Backend.FavoritesManager favorites_manager;
+
 #if HAS_PLANK
     private static Plank.DBusClient plank_client;
     private bool docked = false;
@@ -128,6 +130,25 @@ public class Slingshot.AppContextMenu : Gtk.Menu {
         appcenter.notify["dbus"].connect (() => on_appcenter_dbus_changed.begin (appcenter));
         on_appcenter_dbus_changed.begin (appcenter);
         */
+
+        // Capture desktop_id as a local variable to avoid closure issues
+        string captured_desktop_id = desktop_id;
+
+        favorites_manager = Backend.FavoritesManager.get_default();
+        var is_favorite = favorites_manager.is_favorite (desktop_id);
+        var favorites_item = new Gtk.MenuItem.with_label (
+            is_favorite ? _("Remove from Favorites") : _("Add to Favorites")
+        );
+        favorites_item.activate.connect (() => {
+            // Re-check at execution time
+            if (favorites_manager.is_favorite (captured_desktop_id)) {
+                favorites_manager.remove_favorite (captured_desktop_id);
+            } else {
+                favorites_manager.add_favorite (captured_desktop_id);
+            }
+        });
+        add (favorites_item);
+
         show_all ();
     }
 

--- a/src/Widgets/FavoritesSidebar.vala
+++ b/src/Widgets/FavoritesSidebar.vala
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2026 Ubuntu Budgie Developers
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+public class Slingshot.Widgets.FavoritesSidebar : Gtk.Box {
+    public signal void app_launched ();
+
+    private Gtk.ListBox favorites_list;
+    private Gtk.Button session_button;
+    private AppMenu.PowerStrip powerstrip;
+    private Budgie.Popover? session_popover = null;
+    private Backend.FavoritesManager favorites_manager;
+    private Backend.AppSystem app_system;
+
+    construct {
+        orientation = Gtk.Orientation.VERTICAL;
+        width_request = 64;
+
+        favorites_manager = Backend.FavoritesManager.get_default ();
+
+        var scrolled = new Gtk.ScrolledWindow (null, null);
+        scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
+        scrolled.vexpand = true;
+
+        favorites_list = new Gtk.ListBox ();
+        favorites_list.selection_mode = Gtk.SelectionMode.NONE;
+        favorites_list.get_style_context ().add_class ("favorites-list");
+
+        scrolled.add (favorites_list);
+
+        var separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
+
+        // Session button with icon (like Windows Start button power icon)
+        session_button = new Gtk.Button ();
+        session_button.relief = Gtk.ReliefStyle.NONE;
+        session_button.halign = Gtk.Align.CENTER;
+        session_button.valign = Gtk.Align.CENTER;
+        session_button.margin = 6;
+
+        var session_icon = new Gtk.Image.from_icon_name ("system-shutdown-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
+        session_icon.pixel_size = 24;
+        session_button.add (session_icon);
+        session_button.tooltip_text = _("Power Options");
+
+        var session_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        session_box.pack_start (session_button, false, false, 0);
+
+        pack_start (scrolled, true, true, 0);
+        pack_start (separator, false, false, 0);
+        pack_start (session_box, false, false, 0);
+
+        // Create powerstrip for session popover
+        powerstrip = new AppMenu.PowerStrip (Gtk.Orientation.VERTICAL);
+        powerstrip.invoke_action.connect (() => {
+            if (session_popover != null) {
+                session_popover.hide ();
+            }
+            app_launched ();
+        });
+
+        // Setup popover
+        session_popover = new Budgie.Popover (session_button);
+        session_popover.add (powerstrip);
+        powerstrip.show_all ();
+
+        session_button.clicked.connect (() => {
+            if (session_popover.get_visible ()) {
+                session_popover.hide ();
+            } else {
+                session_popover.show_all ();
+            }
+        });
+
+        favorites_list.row_activated.connect ((row) => {
+            var fav_row = row as FavoriteRow;
+            if (fav_row != null) {
+                fav_row.launch ();
+                app_launched ();
+            }
+        });
+
+        favorites_manager.favorites_changed.connect (() => {
+            populate_favorites ();
+        });
+
+        this.show_all();
+    }
+
+    public void set_app_system (Backend.AppSystem system) {
+        app_system = system;
+        populate_favorites ();
+    }
+
+    public void validate_and_populate () {
+        favorites_manager.validate_favorites ();
+        populate_favorites ();
+    }
+
+    private void populate_favorites () {
+        favorites_list.foreach ((widget) => {
+            widget.destroy ();
+        });
+
+        if (app_system == null) return;
+
+        var favorites = favorites_manager.get_favorites ();
+        var dfs = Synapse.DesktopFileService.get_default ();
+
+        foreach (string desktop_id in favorites) {
+            var info = dfs.get_desktop_file_for_id (desktop_id);
+            if (info != null && !info.is_hidden && info.is_valid) {
+                var row = new FavoriteRow (desktop_id, info.filename);
+                row.show_context_menu.connect ((event) => {
+                    return create_context_menu (event, row);
+                });
+                favorites_list.add (row);
+            }
+        }
+
+        favorites_list.show_all ();
+    }
+
+    private bool create_context_menu (Gdk.Event event, FavoriteRow? row) {
+        if (row == null) return Gdk.EVENT_PROPAGATE;
+
+        // Capture the desktop_id now, not in the callback
+        string desktop_id_to_remove = row.desktop_id;
+
+        // Create menu manually to avoid duplicate "Remove from Favorites"
+        var menu = new Gtk.Menu ();
+
+        // Add "Remove from Favorites" first
+        var remove_item = new Gtk.MenuItem.with_label (_("Remove from Favorites"));
+        remove_item.activate.connect (() => {
+            favorites_manager.remove_favorite (desktop_id_to_remove);
+        });
+        menu.add (remove_item);
+
+        // Get app info for additional actions
+        var app_info = new DesktopAppInfo (row.desktop_id);
+
+        // Add application-specific actions
+        foreach (unowned string _action in app_info.list_actions ()) {
+            string action = _action.dup ();
+            var menuitem = new Gtk.MenuItem.with_mnemonic (app_info.get_action_name (action));
+            menu.add (menuitem);
+
+            menuitem.activate.connect (() => {
+                app_info.launch_action (action, new AppLaunchContext ());
+                app_launched ();
+            });
+        }
+
+        // Only add separator if there are app actions
+        if (app_info.list_actions ().length > 0) {
+            var separator = new Gtk.SeparatorMenuItem ();
+            menu.insert (separator, 1);  // Insert after "Remove from Favorites"
+        }
+
+        // Add GPU selection if available
+        var switcheroo_control = new Slingshot.Backend.SwitcherooControl ();
+        if (switcheroo_control != null && switcheroo_control.has_dual_gpu) {
+            bool prefers_non_default_gpu = app_info.get_boolean ("PrefersNonDefaultGPU");
+            string gpu_name = switcheroo_control.get_gpu_name (prefers_non_default_gpu);
+            string label = _("Open with %s Graphics").printf (gpu_name);
+
+            var menu_item = new Gtk.MenuItem.with_mnemonic (label);
+            menu.add (menu_item);
+
+            menu_item.activate.connect (() => {
+               try {
+                   var context = new AppLaunchContext ();
+                   switcheroo_control.apply_gpu_environment (context, prefers_non_default_gpu);
+                   app_info.launch (null, context);
+                   app_launched ();
+               } catch (Error e) {
+                   warning ("Failed to launch %s: %s", app_info.get_name (), e.message);
+               }
+            });
+        }
+
+#if HAS_PLANK
+        // Add Plank dock integration
+        var plank_client = Plank.DBusClient.get_instance ();
+        if (plank_client != null && plank_client.is_connected) {
+            var desktop_uri = File.new_for_path (row.desktop_path).get_uri ();
+
+            var plank_menuitem = new Gtk.MenuItem ();
+            plank_menuitem.use_underline = true;
+
+            bool docked = (desktop_uri in plank_client.get_persistent_applications ());
+            if (docked) {
+                plank_menuitem.label = _("Remove from _Dock");
+            } else {
+                plank_menuitem.label = _("Add to _Dock");
+            }
+
+            plank_menuitem.activate.connect (() => {
+                if (docked) {
+                    plank_client.remove_item (desktop_uri);
+                } else {
+                    plank_client.add_item (desktop_uri);
+                }
+            });
+
+            menu.add (plank_menuitem);
+        }
+#endif
+
+        menu.show_all ();
+
+        if (event.type == Gdk.EventType.BUTTON_PRESS) {
+            menu.popup_at_pointer (event);
+            return Gdk.EVENT_STOP;
+        }
+
+        return Gdk.EVENT_PROPAGATE;
+    }
+
+    private class FavoriteRow : Gtk.ListBoxRow {
+        public signal bool show_context_menu (Gdk.Event event);
+	public string desktop_id { get; construct; }
+        public string desktop_path { get; construct; }
+        private GLib.DesktopAppInfo app_info;
+        private Gtk.Label? tooltip_label = null;
+        private uint timeout_id = 0;
+
+        public FavoriteRow (string desktop_id, string desktop_path) {
+            Object (
+                desktop_id: desktop_id,
+                desktop_path: desktop_path
+            );
+        }
+
+        construct {
+            app_info = new GLib.DesktopAppInfo (desktop_id);
+
+            var icon = app_info.get_icon ();
+            if (icon == null) {
+                icon = new ThemedIcon ("application-default-icon");
+            }
+
+            var image = new Gtk.Image.from_gicon (icon, Gtk.IconSize.INVALID);
+            image.pixel_size = 32;
+            image.margin = 8;
+
+            var event_box = new Gtk.EventBox ();
+            event_box.add (image);
+            event_box.add_events (Gdk.EventMask.ENTER_NOTIFY_MASK | Gdk.EventMask.LEAVE_NOTIFY_MASK);
+
+            add (event_box);
+
+            // Create persistent tooltip label that will be shown/hidden
+            tooltip_label = new Gtk.Label (null);
+            tooltip_label.set_markup (
+                "<b>%s</b>\n<small>%s</small>".printf (
+                    Markup.escape_text (app_info.get_display_name ()),
+                    Markup.escape_text (app_info.get_description () ?? "")
+                )
+            );
+            tooltip_label.halign = Gtk.Align.START;
+            tooltip_label.margin = 8;
+            tooltip_label.get_style_context ().add_class ("tooltip");
+            tooltip_label.get_style_context ().add_class ("background");
+
+            // Use standard tooltip instead of popover to avoid positioning issues
+            var tooltip_text = app_info.get_display_name ();
+            if (app_info.get_description () != null && app_info.get_description () != "") {
+                tooltip_text += "\n" + app_info.get_description ();
+            }
+            this.tooltip_text = tooltip_text;
+
+            // Connect context menu directly to this row
+            this.button_press_event.connect ((event) => {
+                if (event.button == Gdk.BUTTON_SECONDARY) {
+                    return show_context_menu (event);
+                }
+                return Gdk.EVENT_PROPAGATE;
+            });
+
+            this.key_press_event.connect ((event) => {
+                if (event.keyval == Gdk.Key.Menu) {
+                    return show_context_menu (event);
+                }
+                return Gdk.EVENT_PROPAGATE;
+            });
+        }
+
+        public void launch () {
+            try {
+                var commandline = app_info.get_commandline ();
+                string[] spawn_args = {};
+                const string checkstr = "pkexec";
+
+                if (commandline.contains (checkstr)) {
+                    spawn_args = commandline.split (" ");
+                }
+
+                if (spawn_args.length >= 2 && spawn_args[0] == checkstr) {
+                    string[] spawn_env = Environ.get ();
+                    Pid child_pid;
+                    Process.spawn_async (
+                        "/",
+                        spawn_args,
+                        spawn_env,
+                        SpawnFlags.SEARCH_PATH | SpawnFlags.DO_NOT_REAP_CHILD,
+                        null,
+                        out child_pid
+                    );
+                    ChildWatch.add (child_pid, (pid, status) => {
+                        Process.close_pid (pid);
+                    });
+                } else {
+                    app_info.launch (null, null);
+                }
+            } catch (Error error) {
+                critical (error.message);
+            }
+        }
+    }
+}

--- a/src/Widgets/powerstrip.vala
+++ b/src/Widgets/powerstrip.vala
@@ -74,9 +74,8 @@ class PowerStrip : Gtk.Box
         }
     }
 
-    construct
-    {
-        Gtk.Box? bottom = new Gtk.Box(Gtk.Orientation.HORIZONTAL, 1);
+    public PowerStrip(Gtk.Orientation direction=Gtk.Orientation.HORIZONTAL) {
+        Gtk.Box? bottom = new Gtk.Box(direction, 1);
         //margin_top = 10;
         //get_style_context().add_class("raven-header");
         get_style_context().add_class("powerstrip");
@@ -223,16 +222,3 @@ class PowerStrip : Gtk.Box
 }
 
 } /* End namespace */
-
-/*
- * Editor modelines  -  https://www.wireshark.org/tools/modelines.html
- *
- * Local variables:
- * c-basic-offset: 4
- * tab-width: 4
- * indent-tabs-mode: nil
- * End:
- *
- * vi: set shiftwidth=4 tabstop=4 expandtab:
- * :indentSize=4:tabSize=4:noTabs=true:
- */

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,7 +30,6 @@ custom_target('plugin-appmenu',
     install_dir : wingpanel_indicatorsdir)
 
 sources = [
-    'powerstrip.vala',
     'AppMenu.vala',
     'IconChooser.vala',
     applet_appmenu_resources,
@@ -44,6 +43,7 @@ sources = [
     'Backend/RelevancyService.vala',
     'Backend/SynapseSearch.vala',
     'Backend/SwitcherooControl.vala',
+    'Backend/FavoritesManager.vala',
 
     'Views/CategoryView.vala',
     'Views/GridView.vala',
@@ -56,6 +56,8 @@ sources = [
     'Widgets/Switcher.vala',
     'Widgets/SearchItem.vala',
     'Widgets/PageChecker.vala',
+    'Widgets/FavoritesSidebar.vala',
+    'Widgets/powerstrip.vala',
 
     'synapse-core/Actions/TerminalRunnerAction.vala',
     'synapse-core/Actions/RunnerAction.vala',

--- a/src/settings.ui
+++ b/src/settings.ui
@@ -277,6 +277,29 @@ Spacing</property>
         <property name="top_attach">8</property>
       </packing>
     </child>
+    <child>
+      <object class="GtkLabel">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Favorites</property>
+        <property name="xalign">0</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">9</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkSwitch" id="switch_favorites">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="halign">end</property>
+      </object>
+      <packing>
+        <property name="left_attach">1</property>
+        <property name="top_attach">9</property>
+      </packing>
+    </child>
   </template>
   <object class="GtkSizeGroup" id="szgrp_entries"/>
 </interface>


### PR DESCRIPTION
This adds a sidebar to the menu which allows you to add/remove and launch desktop menu items.

Sidebar items are populated by right-clicking the icon view menu/list view and choosing the Add favourite menu option